### PR TITLE
Added auto-disconnect if voice channel empty

### DIFF
--- a/app.py
+++ b/app.py
@@ -311,7 +311,18 @@ async def disconnect_command(ctx: commands.Context):
         await ctx.send(embed=nextcord.Embed(description='**BYE!** Have a great time!', color=embed_color))
     except Exception:
         await ctx.send(embed=nextcord.Embed(description='Failed to destroy!', color=embed_color))
-            
+
+# Auto-disconnect if all participants leave the voice channel
+@bot.event
+async def on_voice_state_update(member, before, after):
+    if before.channel is not None:
+        if bot.user in before.channel.members:
+            if len(before.channel.members) == 1:
+                for vc in bot.voice_clients:
+                    if vc.channel == before.channel:
+                        await vc.disconnect(force=True)
+                        break         
+         
 @commands.cooldown(1, 2, commands.BucketType.user)
 @bot.command(name='nowplaying', aliases=['np'], help='shows the current track information', description=',np')
 async def nowplaying_command(ctx: commands.Context):


### PR DESCRIPTION
It is convenient for users to not need to manually disconnect the bot when everyone eventually leaves the voice channel. 

This may not solve the remaining issue of users right-clicking `disconnect` menu option in Discord, but it does address the underlying reason of why users might ever be motivated to click that button in the first place, thereby deterring the problem from occurring. 